### PR TITLE
Add standard MET

### DIFF
--- a/python/FrameworkConfiguration.py
+++ b/python/FrameworkConfiguration.py
@@ -359,7 +359,7 @@ def createProcess(isMC, globalTag):
     else:
         process.corrPfMetType1CHS = corrPfMetType1.clone(
             src = 'ak4PFJetsCHS',
-            jetCorrLabel = 'ak4PFL1FastL2L3Corrector',
+            jetCorrLabel = 'ak4PFCHSL1FastL2L3Corrector',
             offsetCorrLabel = 'ak4PFCHSL1FastjetCorrector'
         )
         process.pfMetT1CHS = pfMetT1.clone(


### PR DESCRIPTION
For the moment, only MET created from CHS and PUPPI is kept inside the output file. This PR also adds standard MET (created from all PF candidates) to the output.

I also fixed the payload used for jets corrections for CHS  MET (a 'CHS' was missing)
