### PR TITLE
[BUG FIX] PUPPI muon isolation does NOT require minimul PT cut.

### DIFF
--- a/python/FrameworkConfiguration.py
+++ b/python/FrameworkConfiguration.py
@@ -264,6 +264,9 @@ def createProcess(isMC, globalTag):
             src_charged_hadron = 'pfAllChargedHadronsPuppi',
             src_neutral_hadron = 'pfAllNeutralHadronsPuppi',
             src_photon         = 'pfAllPhotonsPuppi',
+            veto_charged_hadron='Threshold(0.0)',
+            veto_neutral_hadron='Threshold(0.0)',
+            veto_photon='Threshold(0.0)',
             coneR = cone_size
             )
 
@@ -273,6 +276,9 @@ def createProcess(isMC, globalTag):
             src_charged_hadron = 'pfAllChargedHadronsPuppiNoMuon',
             src_neutral_hadron = 'pfAllNeutralHadronsPuppiNoMuon',
             src_photon         = 'pfAllPhotonsPuppiNoMuon',
+            veto_charged_hadron='Threshold(0.0)',
+            veto_neutral_hadron='Threshold(0.0)',
+            veto_photon='Threshold(0.0)',
             coneR = cone_size
             )
 

--- a/python/MuonIsolationTools.py
+++ b/python/MuonIsolationTools.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 from CommonTools.ParticleFlow.Isolation.tools_cfi import isoDepositReplace
 
-def load_muonPFiso_sequence(proc, seq_name, algo, coneR, src, src_charged_hadron='', src_neutral_hadron='', src_photon='', src_charged_pileup=''):
+def load_muonPFiso_sequence(proc, seq_name, algo, coneR, src, src_charged_hadron='', src_neutral_hadron='', src_photon='', src_charged_pileup='', 
+                            veto_charged_hadron='Threshold(0.0)', veto_neutral_hadron='Threshold(0.5)', veto_photon='Threshold(0.5)', veto_charged_pileup='Threshold(0.5)' ):
 
     doCH, doNH, doPh, doPU = False, False, False, False
     if src_charged_hadron != '': doCH = True
@@ -38,7 +39,7 @@ def load_muonPFiso_sequence(proc, seq_name, algo, coneR, src, src_charged_hadron
                 src = cms.InputTag('muPFIsoDepositCH'+algo),
                 deltaR = cms.double(coneR),
                 weight = cms.string('1'),
-                vetos = cms.vstring('0.0001','Threshold(0.0)'),
+                vetos = cms.vstring('0.0001',veto_charged_hadron),
                 skipDefaultVeto = cms.bool(True),
                 mode = cms.string('sum')
               )
@@ -55,7 +56,7 @@ def load_muonPFiso_sequence(proc, seq_name, algo, coneR, src, src_charged_hadron
                 src = cms.InputTag('muPFIsoDepositNH'+algo),
                 deltaR = cms.double(coneR),
                 weight = cms.string('1'),
-                vetos = cms.vstring('0.01','Threshold(0.5)'),
+                vetos = cms.vstring('0.01', veto_neutral_hadron ),
                 skipDefaultVeto = cms.bool(True),
                 mode = cms.string('sum')
               )
@@ -72,7 +73,7 @@ def load_muonPFiso_sequence(proc, seq_name, algo, coneR, src, src_charged_hadron
                 src = cms.InputTag('muPFIsoDepositPh'+algo),
                 deltaR = cms.double(coneR),
                 weight = cms.string('1'),
-                vetos = cms.vstring('0.01','Threshold(0.5)'),
+                vetos = cms.vstring('0.01', veto_photon),
                 skipDefaultVeto = cms.bool(True),
                 mode = cms.string('sum')
               )
@@ -89,7 +90,7 @@ def load_muonPFiso_sequence(proc, seq_name, algo, coneR, src, src_charged_hadron
                 src = cms.InputTag('muPFIsoDepositPU'+algo),
                 deltaR = cms.double(coneR),
                 weight = cms.string('1'),
-                vetos = cms.vstring('0.01','Threshold(0.5)'),
+                vetos = cms.vstring('0.01', veto_charged_pileup ),
                 skipDefaultVeto = cms.bool(True),
                 mode = cms.string('sum')
               )


### PR DESCRIPTION
In the PUPPI muon isolation, PT threshold on the pat candidates is not needed but there was.
I added options to change the thresholds for CH/NH/PH candidates which are passed to the isolation calculator, 
 and for the two PUPPIs (PUPPI with and without muon), threshold of 0 GeV for CH/NH/PH is set.

This has effect only to the muon isolation calculation(PUPPIs).
