### PR TITLE
New variable for GenJet matching.

### DIFF
--- a/interface/JMEJetAnalyzer.h
+++ b/interface/JMEJetAnalyzer.h
@@ -104,4 +104,5 @@ class JMEJetAnalyzer : public JME::PhysicsObjectAnalyzer
         std::vector<float>& allGenJet_phi = tree["allGenJet_phi"].write<std::vector<float>>();
         std::vector<float>& allGenJet_m   = tree["allGenJet_m"  ].write<std::vector<float>>();
         std::vector<bool> & allGenJet_PatJetMatched = tree["allGenJet_patJetmatched"].write<std::vector<bool>>();
+        std::vector<bool> & allGenJet_PatJetWithJetIDMatched = tree["allGenJet_patJetWithJetIDmatched"].write<std::vector<bool>>();
 };

--- a/src/JMEJetAnalyzer.cc
+++ b/src/JMEJetAnalyzer.cc
@@ -246,6 +246,7 @@ void JMEJetAnalyzer::analyze(const edm::Event& iEvent,
     if( genjet.pt () < 5 ) continue ;
 
     bool b_genjet_hasMatchedRecoJet = false ;
+    bool b_genjet_hasMatchedRecoJetWithJetID = false ;
 
     for (size_t iJet = 0; iJet < nJet; iJet++) {
 
@@ -261,6 +262,15 @@ void JMEJetAnalyzer::analyze(const edm::Event& iEvent,
 
       b_genjet_hasMatchedRecoJet = true ;
 
+      if( ! ( jet.neutralEmEnergyFraction->at( i )     < 0.99 ) )  continue  ; 
+      if( ! ( jet.chargedHadronEnergyFraction->at( i ) > 0.0  ) )  continue  ; 
+      if( ! ( jet.neutralHadronEnergyFraction->at( i ) < 0.99 ) )  continue  ; 
+      if( ! ( jet.chargedEmEnergyFraction->at( i )     < 0.99 ) )  continue  ; 
+      if( ! ( jet.nTot->at( i )                        > 1    ) )  continue  ; 
+      if( ! ( jet.chargedMultiplicity->at( i )         > 0    ) )  continue  ; 
+
+      b_genjet_hasMatchedRecoJetWithJetID = true ;
+
     }      
 
     allGenJet_pt  .push_back( genjet.pt  () );
@@ -268,6 +278,7 @@ void JMEJetAnalyzer::analyze(const edm::Event& iEvent,
     allGenJet_phi .push_back( genjet.phi () );
     allGenJet_m   .push_back( genjet.mass() );
     allGenJet_PatJetMatched  .push_back( b_genjet_hasMatchedRecoJet ) ;
+    allGenJet_PatJetWithJetIDMatched  .push_back( b_genjet_hasMatchedRecoJetWithJetID ) ;
 
   }
 

--- a/src/JMEJetAnalyzer.cc
+++ b/src/JMEJetAnalyzer.cc
@@ -262,12 +262,12 @@ void JMEJetAnalyzer::analyze(const edm::Event& iEvent,
 
       b_genjet_hasMatchedRecoJet = true ;
 
-      if( ! ( jet.neutralEmEnergyFraction->at( i )     < 0.99 ) )  continue  ; 
-      if( ! ( jet.chargedHadronEnergyFraction->at( i ) > 0.0  ) )  continue  ; 
-      if( ! ( jet.neutralHadronEnergyFraction->at( i ) < 0.99 ) )  continue  ; 
-      if( ! ( jet.chargedEmEnergyFraction->at( i )     < 0.99 ) )  continue  ; 
-      if( ! ( jet.nTot->at( i )                        > 1    ) )  continue  ; 
-      if( ! ( jet.chargedMultiplicity->at( i )         > 0    ) )  continue  ; 
+      if( ! ( jet.neutralEmEnergyFraction()     < 0.99 ) )  continue  ; 
+      if( ! ( jet.chargedHadronEnergyFraction() > 0.0  ) )  continue  ; 
+      if( ! ( jet.neutralHadronEnergyFraction() < 0.99 ) )  continue  ; 
+      if( ! ( jet.chargedEmEnergyFraction()     < 0.99 ) )  continue  ; 
+      if( ! ( jet.numberOfDaughters()           > 1    ) )  continue  ; 
+      if( ! ( jet.chargedMultiplicity()         > 0    ) )  continue  ; 
 
       b_genjet_hasMatchedRecoJetWithJetID = true ;
 


### PR DESCRIPTION
New variable is added.
It tells if the gen-jet is matched to any jet that passes jet ID criteria.
(Already matching flag "allGenJet_patJetmatched" (gen->reco) exists but it does not care jet ID.)
